### PR TITLE
Add check for NaNs in aaft and iaaft

### DIFF
--- a/src/aaft.jl
+++ b/src/aaft.jl
@@ -14,7 +14,7 @@ J. Theiler et al., Physica D *58* (1992) 77-94 (1992).
 
 """
 function aaft(ts::AbstractArray{T, 1} where T)
-    any(isnan.(ts)) && error("The input must not contain NaN values.")
+    any(isnan.(ts)) && throw(DomainError(NaN, "The input must not contain NaN values"))
     n = length(ts)
 
     # Indices that would sort `ts` in ascending order

--- a/src/aaft.jl
+++ b/src/aaft.jl
@@ -14,6 +14,7 @@ J. Theiler et al., Physica D *58* (1992) 77-94 (1992).
 
 """
 function aaft(ts::AbstractArray{T, 1} where T)
+    any(isnan.(ts)) && error("The input must not contain NaN values.")
     n = length(ts)
 
     # Indices that would sort `ts` in ascending order

--- a/src/iaaft.jl
+++ b/src/iaaft.jl
@@ -27,7 +27,8 @@ PMID 10062864. [https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.77.635
 """
 function iaaft(ts::AbstractVector{T} where T;
                 n_maxiter = 200, tol = 1e-6, n_windows = 50)
-
+    any(isnan.(ts)) && error("The input must not contain NaN values.")
+	
     # Sorted version of the original time series
     original_sorted = sort(ts)
 

--- a/src/iaaft.jl
+++ b/src/iaaft.jl
@@ -27,7 +27,7 @@ PMID 10062864. [https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.77.635
 """
 function iaaft(ts::AbstractVector{T} where T;
                 n_maxiter = 200, tol = 1e-6, n_windows = 50)
-    any(isnan.(ts)) && error("The input must not contain NaN values.")
+    any(isnan.(ts)) && throw(DomainError(NaN,"The input must not contain NaN values."))
 	
     # Sorted version of the original time series
     original_sorted = sort(ts)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,8 @@ using TimeseriesSurrogates
 ENV["GKSwstype"] = "100"
 
 ts = cumsum(randn(1000))
+ts_nan =cumsum(randn(100)) 
+ts_nan[1] = NaN
 
 @testset "Constrained surrogates" begin
     @testset "Random shuffle" begin
@@ -29,6 +31,7 @@ ts = cumsum(randn(1000))
         @test length(ts) == length(surrogate)
         #@test all(ts .!= surrogate)
         @test all(sort(ts) .== sort(surrogate))
+	@test_throws DomainError aaft(ts_nan)
     end
 
     @testset "IAAFT" begin
@@ -44,6 +47,7 @@ ts = cumsum(randn(1000))
         @test length(ts) == length(surrogates[1])
         #@test all(ts .!= surrogates[end])
         @test all(sort(ts) .== sort(surrogates[end]))
+	@test_throws DomainError iaaft(ts_nan)
     end
 
     @testset "WIAAFT" begin


### PR DESCRIPTION
If there is a NaN value in the time series, these methods return the
sorted time series.
Closes #10 